### PR TITLE
test(server): validate gemini_local routing fix with explicit test

### DIFF
--- a/server/src/__tests__/gemini-routing-engine.test.ts
+++ b/server/src/__tests__/gemini-routing-engine.test.ts
@@ -338,4 +338,81 @@ describe("resolveGeminiRoutingPreflight extended fields", () => {
     expect(result!.selected.effectiveModelLane).toBe("gemini-3.1-pro-preview");
     expect(result!.routingReason).toContain("role=ceo");
   });
+
+  it("keeps adapterConfig.model on auto even when applyModelLane is true", () => {
+    const adapterConfig = { model: "auto" };
+
+    const result = resolveGeminiRoutingPreflight({
+      adapterType: "gemini_local",
+      adapterConfig,
+      runtimeConfig: {
+        routingPolicy: {
+          mode: "soft_enforced",
+          bucketState: {
+            flash: "ok",
+            pro: "ok",
+            "flash-lite": "ok",
+          },
+        },
+      },
+      context: {
+        role: "ceo",
+      },
+    });
+
+    expect(result).not.toBeNull();
+    expect(result!.applyModelLane).toBe(true);
+    expect(result!.selected.effectiveModelLane).toBe("gemini-3.1-pro-preview");
+    expect(adapterConfig.model).toBe("auto");
+  });
+
+  it("still mutates explicit adapterConfig.model when applyModelLane is true", () => {
+    const adapterConfig = { model: "gemini-3-flash-preview" };
+
+    const result = resolveGeminiRoutingPreflight({
+      adapterType: "gemini_local",
+      adapterConfig,
+      runtimeConfig: {
+        routingPolicy: {
+          mode: "soft_enforced",
+          bucketState: {
+            flash: "ok",
+            pro: "ok",
+            "flash-lite": "ok",
+          },
+        },
+      },
+      context: {
+        role: "ceo",
+      },
+    });
+
+    expect(result).not.toBeNull();
+    expect(result!.applyModelLane).toBe(true);
+    expect(adapterConfig.model).toBe("gemini-3.1-pro-preview");
+  });
+
+  it("packetType free_api keeps model: auto", () => {
+    const adapterConfig = { model: "auto" };
+    const result = resolveGeminiRoutingPreflight({
+      adapterType: "gemini_local",
+      adapterConfig,
+      runtimeConfig: {
+        routingPolicy: {
+          mode: "soft_enforced",
+          bucketState: { flash: "ok", pro: "ok", "flash-lite": "ok" },
+        },
+      },
+      context: {
+        packetType: "free_api",
+        role: "worker",
+      },
+    });
+
+    expect(result).not.toBeNull();
+    expect(result!.laneDecision.lane).toBe("free_api");
+    expect(result!.applyModelLane).toBe(true);
+    expect(result!.selected.effectiveModelLane).toBe("gemini-2.5-flash-lite");
+    expect(adapterConfig.model).toBe("auto");
+  });
 });

--- a/server/src/services/gemini-routing.ts
+++ b/server/src/services/gemini-routing.ts
@@ -566,7 +566,11 @@ export function resolveGeminiRoutingPreflight(
     input.context.budgetClass = result.selected.budgetClass;
   }
 
-  if (result.applyModelLane) {
+  const configuredModel = asString(input.adapterConfig.model);
+  const shouldMutateAdapterModel =
+    result.applyModelLane && configuredModel !== null && configuredModel !== "auto";
+
+  if (shouldMutateAdapterModel) {
     input.adapterConfig.model = result.selected.effectiveModelLane;
   }
 


### PR DESCRIPTION
Goal: Ensure or add a dedicated test case in server/src/__tests__/gemini-routing-engine.test.ts that explicitly proves model: auto remains stable.
Result: Added 3 test cases to verify model: auto stability and explicit model mutation. Also included the fix in gemini-routing.ts that was already present in the worktree.
Files Changed: server/src/__tests__/gemini-routing-engine.test.ts, server/src/services/gemini-routing.ts
Blockers: none
Next: review and merge