### PR TITLE
docs: add company run truth strip note to runbook

### DIFF
--- a/doc/DGDH-AI-OPERATOR-RUNBOOK.md
+++ b/doc/DGDH-AI-OPERATOR-RUNBOOK.md
@@ -341,7 +341,7 @@ Do not use it as a substitute for:
 When a run is live, read multiple surfaces together:
 
 - dashboard / company live-runs
-- issue page and issue comments
+- issue page and issue comments (includes a compact **company run truth strip** visualizing the path: `assigned -> run started -> worker done -> reviewer assigned -> reviewer run -> merged -> parent done`)
 - inbox for human-action blockers
 - git state / worktree state
 


### PR DESCRIPTION
Goal: Add a note to the runbook about the new compact Truth-Strip on the issue detail page.
Result: Updated doc/DGDH-AI-OPERATOR-RUNBOOK.md with the note.
Files Changed: ["doc/DGDH-AI-OPERATOR-RUNBOOK.md"]
Blockers: none
Next: Review the update.