### PR TITLE
doc: add kickoff-probe note to Runbook

### DIFF
--- a/doc/DGDH-AI-OPERATOR-RUNBOOK.md
+++ b/doc/DGDH-AI-OPERATOR-RUNBOOK.md
@@ -158,6 +158,8 @@ Assume:
 - API truth beats browser state
 - use exact tools or direct API/file probes first; do not start with broad terminal scans when one precise check would answer the question
 
+> **Kickoff-Probe Rule:** Perform a minimal, non-destructive API check (e.g., `GET /api/companies`) right at the start to verify connectivity and identity before assigning issues or creating projects. This prevents "kickoff loss" before committing to a run.
+
 PowerShell pattern:
 
 ```powershell


### PR DESCRIPTION
Goal: Add kickoff-probe note to Runbook
Result: Added the 'kickoff-probe' rule to Section 7.1 of the Operator Runbook to help prevent 'kickoff loss' by verifying connectivity and identity early in a session.
Files Changed:
- doc/DGDH-AI-OPERATOR-RUNBOOK.md
Blockers: none
Next: Reviewer verification.